### PR TITLE
fix(tests): serialize AffordanceRegistry tests to remove flake

### DIFF
--- a/Tests/DomainTests/Shared/AffordanceRegistryTests.swift
+++ b/Tests/DomainTests/Shared/AffordanceRegistryTests.swift
@@ -66,4 +66,45 @@ struct AffordanceRegistryTests {
         #expect(link.method == "POST")
         #expect(link.href.contains("simulators"))
     }
+
+    // MARK: - Plugin affordances merged into a real domain model
+    //
+    // These live here, not in SimulatorTests, on purpose. AffordanceRegistry is
+    // process-global mutable state, and `.serialized` only orders tests *within*
+    // a suite — separate suites still run concurrently. Any test that registers a
+    // provider must therefore share this one serialized suite, or `init()`'s reset
+    // will wipe its registration mid-test. Register from anywhere else and you
+    // reintroduce a flake that only shows up under parallel scheduling.
+
+    @Test func `booted simulator affordances include plugin stream when registered`() {
+        AffordanceRegistry.register(Simulator.self) { id, props in
+            guard props["isBooted"] == "true" else { return [] }
+            return [Affordance(key: "stream", command: "simulators", action: "stream", params: ["udid": id])]
+        }
+        let sim = MockRepositoryFactory.makeSimulator(id: "SIM-1", state: .booted)
+        // Plugin affordance should be merged into the model's own affordances
+        #expect(sim.affordances["stream"] == "asc simulators stream --udid SIM-1")
+        // Model's own affordances still present
+        #expect(sim.affordances["shutdown"] == "asc simulators shutdown --udid SIM-1")
+    }
+
+    @Test func `shutdown simulator does not get stream affordance from plugin`() {
+        AffordanceRegistry.register(Simulator.self) { id, props in
+            guard props["isBooted"] == "true" else { return [] }
+            return [Affordance(key: "stream", command: "simulators", action: "stream", params: ["udid": id])]
+        }
+        let sim = MockRepositoryFactory.makeSimulator(id: "SIM-2", state: .shutdown)
+        #expect(sim.affordances["stream"] == nil)
+    }
+
+    @Test func `booted simulator apiLinks include plugin stream when registered`() {
+        AffordanceRegistry.register(Simulator.self) { id, props in
+            guard props["isBooted"] == "true" else { return [] }
+            return [Affordance(key: "stream", command: "simulators", action: "stream", params: ["udid": id])]
+        }
+        let sim = MockRepositoryFactory.makeSimulator(id: "SIM-1", state: .booted)
+        // Plugin affordance should appear in REST links too
+        #expect(sim.apiLinks["stream"] != nil)
+        #expect(sim.apiLinks["stream"]?.method == "POST")
+    }
 }

--- a/Tests/DomainTests/Simulators/SimulatorTests.swift
+++ b/Tests/DomainTests/Simulators/SimulatorTests.swift
@@ -151,41 +151,7 @@ struct SimulatorTests {
         #expect(sim.registryProperties["isBooted"] == "false")
     }
 
-    @Test(.serialized) func `booted simulator affordances include plugin stream when registered`() {
-        AffordanceRegistry.reset()
-        AffordanceRegistry.register(Simulator.self) { id, props in
-            guard props["isBooted"] == "true" else { return [] }
-            return [Affordance(key: "stream", command: "simulators", action: "stream", params: ["udid": id])]
-        }
-        let sim = MockRepositoryFactory.makeSimulator(id: "SIM-1", state: .booted)
-        // Plugin affordance should be merged into the model's own affordances
-        #expect(sim.affordances["stream"] == "asc simulators stream --udid SIM-1")
-        // Model's own affordances still present
-        #expect(sim.affordances["shutdown"] == "asc simulators shutdown --udid SIM-1")
-        AffordanceRegistry.reset()
-    }
-
-    @Test(.serialized) func `shutdown simulator does not get stream affordance from plugin`() {
-        AffordanceRegistry.reset()
-        AffordanceRegistry.register(Simulator.self) { id, props in
-            guard props["isBooted"] == "true" else { return [] }
-            return [Affordance(key: "stream", command: "simulators", action: "stream", params: ["udid": id])]
-        }
-        let sim = MockRepositoryFactory.makeSimulator(id: "SIM-2", state: .shutdown)
-        #expect(sim.affordances["stream"] == nil)
-        AffordanceRegistry.reset()
-    }
-
-    @Test(.serialized) func `booted simulator apiLinks include plugin stream when registered`() {
-        AffordanceRegistry.reset()
-        AffordanceRegistry.register(Simulator.self) { id, props in
-            guard props["isBooted"] == "true" else { return [] }
-            return [Affordance(key: "stream", command: "simulators", action: "stream", params: ["udid": id])]
-        }
-        let sim = MockRepositoryFactory.makeSimulator(id: "SIM-1", state: .booted)
-        // Plugin affordance should appear in REST links too
-        #expect(sim.apiLinks["stream"] != nil)
-        #expect(sim.apiLinks["stream"]?.method == "POST")
-        AffordanceRegistry.reset()
-    }
+    // Tests that register plugin providers for Simulator live in
+    // AffordanceRegistryTests — they need that suite's serialized scope because
+    // AffordanceRegistry is process-global. See the note there before adding more.
 }


### PR DESCRIPTION
## Problem

Two tests fail intermittently under parallel scheduling:

- `booted simulator apiLinks include plugin stream when registered`
- `booted simulator affordances include plugin stream when registered`

```
✘ Expectation failed: (sim.apiLinks["stream"] → nil) != nil
   SimulatorTests.swift:187
```

## Root cause

`AffordanceRegistry` (`Sources/Domain/Shared/AffordanceRegistry.swift`) is process-global mutable state. Two suites in `DomainTests` touch it:

- `AffordanceRegistryTests` — `@Suite(.serialized)`, calls `AffordanceRegistry.reset()` in `init()` before every test
- `SimulatorTests` — plain parallel `@Suite`; three tests `register()` a provider and then assert on the merged affordance

`.serialized` only orders tests **within** a suite — separate suites still run concurrently. So `AffordanceRegistryTests.init()`'s `reset()` lands between `SimulatorTests`' `register()` and its assertion, and the affordance reads back `nil`.

The `.serialized` trait on the individual test *functions* does not help here: it scopes parameterized cases, not cross-test isolation. That's why the three Simulator plugin tests were also racing each other — both affected tests register a provider for `Simulator` and reset at entry.

## Fix

Move the three registry-touching Simulator tests into the serialized `AffordanceRegistryTests` suite, so every test that mutates the global registry shares one serial scope.

- Assertions are unchanged — the tests only moved.
- The redundant inline `reset()` calls are dropped; the suite's `init()` already resets.
- Comments added at both sites explaining why registering a provider from any other suite reintroduces the flake.

Test-only change; no production code touched.

`Tests/ASCCommandTests/.../SimulatorsListTests.swift` also calls `reset()`, but it never registers a provider and nothing else in that target does either, so it is unaffected and left alone.

## Verification

`swift test --filter "SimulatorTests|AffordanceRegistryTests"`, 20 runs each:

| | failed runs |
|---|---|
| before | **15 / 20** |
| after | **0 / 20** |

Full suite: 5/5 green, 2383 tests — unchanged count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage confirming stream options and API links appear for booted simulators.
  - Verified stream options are not provided for shut-down simulators.
  - Consolidated registry behavior checks into a dedicated test area for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->